### PR TITLE
feat: typescript types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,4 @@ build:
 	esbuild --bundle --minify --target=es2021 --format=iife src/sqlean.js --outfile=dist/sqlean.js
 	esbuild --bundle --minify --target=es2021 --format=esm src/sqlean.mjs --outfile=dist/sqlean.mjs
 	cp src/sqlean.wasm dist/sqlean.wasm
+	curl -s -S -L -o "dist/sqlean.d.ts" "https://raw.githubusercontent.com/sqlite/sqlite-wasm/refs/heads/main/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     },
     "type": "module",
     "exports": {
-        ".": "./dist/sqlean.mjs",
+        ".": {
+            "types": "./dist/sqlean.d.ts",
+            "default": "./dist/sqlean.mjs"
+        },
         "./sqlean.wasm": "./dist/sqlean.wasm",
         "./package.json": "./package.json"
     },


### PR DESCRIPTION
Closes #6

Because this package is a drop-in replacement for [`@sqlite.org/sqlite-wasm`](https://www.npmjs.com/package/@sqlite.org/sqlite-wasm), their types cover most of this library too.  

This PR downloads their types in the `Makefile` and references the types in the `package.json`.

---

I would like to contribute more to [`sqlean.js`](https://www.npmjs.com/package/@antonz/sqlean):
- By contributing PRs that solve issues, like #6 
- By creating another file (besides `dist/sqlean.js` and `dist/sqlean.mjs`) to support alternative runtimes, see #7
  - I don’t need the full source to compile wasm or anything like that.  Just the `src/sqlean.mjs` would be enough.  Barring that, I can contribute a patch to the minified code if that’s really needed.  But, I think a patch of minified code is unlikely to be accepted in a PR.
- By supporting these projects
  - I previously purchased and enjoyed reading *SQL Window Functions Explained* (I would love a followup covering the new json functions!)
  - I would be willing to fund the review of this and other PRs I write (I wasn’t able to find a donation link)
  - I am, of course, subscribed to the newsletter.  I would like to spread the word of this repo too, but am trying to add features to push the project forward first