### PR TITLE
feat: export conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 build:
+	esbuild --bundle --target=es2021 --format=iife src/sqlean.js --outfile=dist/sqlean.dev.js
+	esbuild --bundle --target=es2021 --format=esm src/sqlean.mjs --outfile=dist/sqlean.dev.mjs
 	esbuild --bundle --minify --target=es2021 --format=iife src/sqlean.js --outfile=dist/sqlean.js
 	esbuild --bundle --minify --target=es2021 --format=esm src/sqlean.mjs --outfile=dist/sqlean.mjs
 	cp src/sqlean.wasm dist/sqlean.wasm

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "type": "module",
     "exports": {
         ".": {
+            "development": "./dist/sqlean.dev.mjs",
+            "production": "./dist/sqlean.mjs",
             "types": "./dist/sqlean.d.ts",
             "default": "./dist/sqlean.mjs"
         },


### PR DESCRIPTION
Closes #7

Adds export conditions to solve two issues with sqlean.js:
- A development build gives significantly better debugging experiences when encountering errors by including function names and a navigable file. 
- A development build allows users to easily patch the package to support other runtimes
  - Minified patches are harder to write and debug
  - Minified patches must be rewritten on most releases when all function names are regenerated

The exports field now contains both minified production and separate development builds.  

Rather than rename the minified scripts to `.min.js`, I chose to use `.dev.js` to avoid any breaking changes.